### PR TITLE
Introduce testplan feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/api v0.25.0 // indirect
 	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece // indirect
 	gopkg.in/ini.v1 v1.56.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 	k8s.io/api v0.17.6
 	k8s.io/apimachinery v0.17.6

--- a/internal/cmd/buildrun-testplan.go
+++ b/internal/cmd/buildrun-testplan.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2020 The Homeport Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/homeport/build-load/internal/load"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var buildRunTestplanCmdSettings struct {
+	testplanPath string
+}
+
+var buildRunTestplanCmd = &cobra.Command{
+	Use:           "buildruns-testplan",
+	Short:         "Creates and executes buildruns specified in a testplan",
+	Long:          "Creates and executes buildruns specified in a testplan",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		kubeAccess, err := load.NewKubeAccess()
+		if err != nil {
+			return err
+		}
+
+		testplan, err := loadTestPlan(buildRunTestplanCmdSettings.testplanPath)
+		if err != nil {
+			return err
+		}
+
+		return load.ExecuteTestPlan(*kubeAccess, *testplan)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(buildRunTestplanCmd)
+
+	buildRunTestplanCmd.Flags().SortFlags = false
+	buildRunTestplanCmd.PersistentFlags().SortFlags = false
+
+	buildRunTestplanCmd.Flags().StringVar(&buildRunTestplanCmdSettings.testplanPath, "testplan", "", "testplan configuration file")
+}
+
+func loadTestPlan(path string) (*load.TestPlan, error) {
+	var data []byte
+	var err error
+
+	switch path {
+	case "-":
+		data, err = ioutil.ReadAll(os.Stdin)
+
+	default:
+		data, err = ioutil.ReadFile(path)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var testplan load.TestPlan
+	if err := yaml.Unmarshal(data, &testplan); err != nil {
+		return nil, err
+	}
+
+	// apply implicit defaults
+	for i := range testplan.Steps {
+		if len(testplan.Steps[i].BuildRunSettings.Source.Dockerfile) == 0 {
+			testplan.Steps[i].BuildRunSettings.Source.Dockerfile = "Dockerfile"
+		}
+
+		if len(testplan.Steps[i].BuildRunSettings.Source.ContextDir) == 0 {
+			testplan.Steps[i].BuildRunSettings.Source.ContextDir = "/"
+		}
+	}
+
+	return &testplan, nil
+}

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -72,15 +72,15 @@ func applyBuildRunSettingsFlags(cmd *cobra.Command, config *load.BuildRunSetting
 	pf.StringVar(&config.Name, "name", "test", "name to used for kube resources")
 	pf.StringVar(&config.Prefix, "prefix", "load", "prefix for kube resource names")
 
-	pf.StringVar(&config.SourceURL, "source-url", "", "specify source URL to build from")
-	pf.StringVar(&config.SourceContextDir, "source-context", "/", "specify directory to be used in the source repository")
-	pf.StringVar(&config.SourceSecret, "source-secret", "", "specify secret to be used to access the source")
+	pf.StringVar(&config.Source.URL, "source-url", "", "specify source URL to build from")
+	pf.StringVar(&config.Source.ContextDir, "source-context", "/", "specify directory to be used in the source repository")
+	pf.StringVar(&config.Source.SecretRef, "source-secret", "", "specify secret to be used to access the source")
 
-	pf.StringVar(&config.Dockerfile, "dockerfile", "Dockerfile", "specify name of the docker file for kaniko builds")
+	pf.StringVar(&config.Source.Dockerfile, "dockerfile", "Dockerfile", "specify name of the docker file for kaniko builds")
 
-	pf.StringVar(&config.TargetRegistryHostname, "output-registry-hostname", "", "output registry hostname")
-	pf.StringVar(&config.TargetRegistryNamespace, "output-registry-namespace", "", "output registry namespace")
-	pf.StringVar(&config.TargetRegistrySecretRef, "output-registry-secret-ref", "", "secret that contains the access credentials for the output registry")
+	pf.StringVar(&config.Output.RegistryHostname, "output-registry-hostname", "", "output registry hostname")
+	pf.StringVar(&config.Output.RegistryNamespace, "output-registry-namespace", "", "output registry namespace")
+	pf.StringVar(&config.Output.SecretRef, "output-registry-secret-ref", "", "secret that contains the access credentials for the output registry")
 
 	cobra.MarkFlagRequired(pf, "build-type")
 	cobra.MarkFlagRequired(pf, "source-url")

--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -253,6 +253,26 @@ func ExecuteSeriesOfParallelBuildRuns(kubeAccess KubeAccess, config BuildRunSett
 	return results, nil
 }
 
+// ExecuteTestPlan executes the given test plan step by step
+func ExecuteTestPlan(kubeAccess KubeAccess, testplan TestPlan) error {
+	for i, step := range testplan.Steps {
+		bunt.Printf("Running test plan step %d/%d: LightSlateGray{%s}, build type *%s* using cluster build strategy _%s_ to build CornflowerBlue{~%s~}\n",
+			i+1,
+			len(testplan.Steps),
+			step.Name,
+			step.BuildRunSettings.BuildType,
+			step.BuildRunSettings.ClusterBuildStrategy,
+			step.BuildRunSettings.Source.URL,
+		)
+
+		if _, err := ExecuteSingleBuildRun(kubeAccess, step.Name, step.BuildRunSettings); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func estimateResourceRequests(clusterBuildStrategy buildv1.ClusterBuildStrategy, concurrent int64) corev1.ResourceList {
 	var (
 		maxCPU *resource.Quantity

--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -161,7 +161,7 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, name string, config BuildRunSe
 		return nil, err
 	}
 
-	defer deleteContainerImage(kubeAccess, buildRun.Namespace, config.TargetRegistrySecretRef, buildRun.Status.BuildSpec.Output.ImageURL)
+	defer deleteContainerImage(kubeAccess, buildRun.Namespace, config.Output.SecretRef, buildRun.Status.BuildSpec.Output.ImageURL)
 
 	taskRun, err := lookUpTaskRun(kubeAccess.DynClient, config.Namespace, *buildRun)
 	if err != nil {

--- a/internal/load/kubeops.go
+++ b/internal/load/kubeops.go
@@ -53,8 +53,8 @@ func newBuild(name string, config BuildRunSettings) buildv1.Build {
 
 		Spec: buildv1.BuildSpec{
 			Source: buildv1.GitSource{
-				URL:        config.SourceURL,
-				ContextDir: &config.SourceContextDir,
+				URL:        config.Source.URL,
+				ContextDir: &config.Source.ContextDir,
 			},
 
 			StrategyRef: &buildv1.StrategyRef{
@@ -64,8 +64,8 @@ func newBuild(name string, config BuildRunSettings) buildv1.Build {
 
 			Output: buildv1.Image{
 				ImageURL: fmt.Sprintf("%s/%s/%s",
-					config.TargetRegistryHostname,
-					config.TargetRegistryNamespace,
+					config.Output.RegistryHostname,
+					config.Output.RegistryNamespace,
 					name,
 				),
 			},
@@ -73,23 +73,23 @@ func newBuild(name string, config BuildRunSettings) buildv1.Build {
 	}
 
 	// Optional: source registry access credentials
-	if len(config.SourceSecret) > 0 {
+	if len(config.Source.SecretRef) > 0 {
 		build.Spec.Source.SecretRef = &corev1.LocalObjectReference{
-			Name: config.SourceSecret,
+			Name: config.Source.SecretRef,
 		}
 	}
 
 	// Optional: target/output registry access credentials
-	if len(config.TargetRegistrySecretRef) > 0 {
+	if len(config.Output.SecretRef) > 0 {
 		build.Spec.Output.SecretRef = &corev1.LocalObjectReference{
-			Name: config.TargetRegistrySecretRef,
+			Name: config.Output.SecretRef,
 		}
 	}
 
 	// build type specific spec updates
 	switch config.BuildType {
 	case "kaniko":
-		build.Spec.Dockerfile = &config.Dockerfile
+		build.Spec.Dockerfile = &config.Source.Dockerfile
 
 	case "buildpacks":
 		// nothing additional to set

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -54,22 +54,26 @@ type BuildRunResult struct {
 // BuildRunSettings contains all required settings for a buildrun
 type BuildRunSettings struct {
 	// type settings
-	ClusterBuildStrategy string
-	BuildType            string
+	ClusterBuildStrategy string `yaml:"clusterBuildStrategy"`
+	BuildType            string `yaml:"buildType"`
 
 	// location and test resource naming settings
-	Namespace string
-	Prefix    string
-	Name      string
+	Namespace string `yaml:"namespace"`
+	Prefix    string `yaml:"prefix"`
+	Name      string `yaml:"name"`
 
 	// build source settings
-	SourceURL        string
-	SourceContextDir string
-	Dockerfile       string
-	SourceSecret     string
+	Source struct {
+		SecretRef  string `yaml:"secretRef"`
+		URL        string `yaml:"url"`
+		ContextDir string `yaml:"contextDir"`
+		Dockerfile string `yaml:"dockerfile"`
+	} `yaml:"source"`
 
-	// build target settings
-	TargetRegistryHostname  string
-	TargetRegistryNamespace string
-	TargetRegistrySecretRef string
+	// build output settings
+	Output struct {
+		SecretRef         string `yaml:"secretRef"`
+		RegistryHostname  string `yaml:"registryHostname"`
+		RegistryNamespace string `yaml:"registryNamespace"`
+	} `yaml:"output"`
 }

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -77,3 +77,11 @@ type BuildRunSettings struct {
 		RegistryNamespace string `yaml:"registryNamespace"`
 	} `yaml:"output"`
 }
+
+// TestPlan is a plan with steps that define tests
+type TestPlan struct {
+	Steps []struct {
+		Name             string           `yaml:"name"`
+		BuildRunSettings BuildRunSettings `yaml:"buildRunConfig"`
+	} `yaml:"steps"`
+}


### PR DESCRIPTION
It can be useful to run multiple different builds in a sequence to test
that each of those builds runs through successfully.

Add command that takes a test plan YAML with multiple buildrun settings.

Add code to execute buildruns from a list of test plan steps.

Improve error message in case a buildrun fails to include all the logs
of all the containers of the respective taskrun pod.

Example using a heredoc:

```sh
#!/bin/bash

set -euo pipefail

cat <<EOY | build-load buildruns-testplan --testplan -
---
steps:
- name: kaniko
  buildRunConfig:
    buildType: kaniko
    clusterBuildStrategy: kaniko
    namespace: test-namespace
    source:
      url: https://github.com/EmilyEmily/docker-simple
    output:
      registryHostname: docker.io
      registryNamespace: boatyard
      secretRef: reg-cred

- name: buildpacks
  buildRunConfig:
    buildType: buildpacks
    clusterBuildStrategy: buildpacks-v3
    namespace: test-namespace
    source:
      url: https://github.com/cloudfoundry/cf-acceptance-tests
      contextDir: assets/catnip
    output:
      registryHostname: docker.io
      registryNamespace: boatyard
      secretRef: reg-cred

EOY

```