### PR TITLE
Switch to build and tekton clientsets 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b // indirect
 	github.com/mitchellh/mapstructure v1.3.1 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/shipwright-io/build v0.1.0
+	github.com/shipwright-io/build v0.1.1-0.20201015051941-5d89593d58ad
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	github.com/tektoncd/pipeline v0.14.2

--- a/go.sum
+++ b/go.sum
@@ -1070,8 +1070,8 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/shipwright-io/build v0.1.0 h1:c8f6/OZHInYdTHaXmEvCZeLRloiuH8B5VX4xrBgYvSc=
-github.com/shipwright-io/build v0.1.0/go.mod h1:J+4gcuT1JvtRNcB8fbCO+1roG9ep2L3JJsHKJ6vU+MI=
+github.com/shipwright-io/build v0.1.1-0.20201015051941-5d89593d58ad h1:+GVq3QpS9tvLI5Tty6qy3bLictPkM+tNcX4Gf5fl8xY=
+github.com/shipwright-io/build v0.1.1-0.20201015051941-5d89593d58ad/go.mod h1:DSk6I2aMWPZY1r/ZEAvqsHOf9KmelKHuaKHAbHjc074=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/githubv4 v0.0.0-20180925043049-51d7b505e2e9/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=

--- a/internal/load/common.go
+++ b/internal/load/common.go
@@ -21,7 +21,9 @@ import (
 	"path/filepath"
 
 	buildv1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildclient "github.com/shipwright-io/build/pkg/client/build/clientset/versioned"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/wrap"
@@ -102,10 +104,22 @@ func NewKubeAccess() (*KubeAccess, error) {
 		return nil, err
 	}
 
+	buildClient, err := buildclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	tektonClient, err := tektonclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &KubeAccess{
-		RestConfig: restConfig,
-		Client:     client,
-		DynClient:  dynClient,
+		RestConfig:   restConfig,
+		Client:       client,
+		DynClient:    dynClient,
+		BuildClient:  buildClient,
+		TektonClient: tektonClient,
 	}, nil
 }
 

--- a/internal/load/kubeops.go
+++ b/internal/load/kubeops.go
@@ -142,6 +142,10 @@ func waitForBuildRunCompletion(kubeAccess KubeAccess, buildRun *buildv1.BuildRun
 		name      = buildRun.Name
 	)
 
+	if buildRun.Spec.Timeout != nil {
+		timeout = buildRun.Spec.Timeout.Duration
+	}
+
 	err := wait.PollImmediate(5*time.Second, timeout, func() (done bool, err error) {
 		buildRun, err = kubeAccess.BuildClient.BuildV1alpha1().BuildRuns(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -19,6 +19,8 @@ package load
 import (
 	"time"
 
+	buildclient "github.com/shipwright-io/build/pkg/client/build/clientset/versioned"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -26,9 +28,11 @@ import (
 
 // KubeAccess contains Kubernetes cluster access objects in a single place
 type KubeAccess struct {
-	RestConfig *rest.Config
-	Client     kubernetes.Interface
-	DynClient  dynamic.Interface
+	RestConfig   *rest.Config
+	Client       kubernetes.Interface
+	DynClient    dynamic.Interface
+	BuildClient  buildclient.Interface
+	TektonClient tektonclient.Interface
 }
 
 // BuildRunResultSet is an aggregated result set based on multiple


### PR DESCRIPTION
Since a clientset is available for both build and tekton, there is no
need to use the dynamic client.

Switch to build clientset for build, buildruns and clusterbuildstrategy.

Switch to tekton clientset for taskrun.

Refactor wait function to use wait polling from kube package.