### PR TITLE
Add namespace override for testplan

### DIFF
--- a/internal/cmd/buildrun-testplan.go
+++ b/internal/cmd/buildrun-testplan.go
@@ -25,6 +25,7 @@ import (
 )
 
 var buildRunTestplanCmdSettings struct {
+	namespace    string
 	testplanPath string
 }
 
@@ -80,6 +81,11 @@ var buildRunTestplanCmd = &cobra.Command{
 			return err
 		}
 
+		// Override testplan namespace if command line flag namespace is used
+		if len(buildRunTestplanCmdSettings.namespace) > 0 {
+			testplan.Namespace = buildRunTestplanCmdSettings.namespace
+		}
+
 		return load.ExecuteTestPlan(*kubeAccess, *testplan)
 	},
 }
@@ -90,6 +96,7 @@ func init() {
 	buildRunTestplanCmd.Flags().SortFlags = false
 	buildRunTestplanCmd.PersistentFlags().SortFlags = false
 
+	buildRunTestplanCmd.Flags().StringVar(&buildRunTestplanCmdSettings.namespace, "namespace", "", "namespace to run tests in (takes precedence over namespace in testplan YAML)")
 	buildRunTestplanCmd.Flags().StringVar(&buildRunTestplanCmdSettings.testplanPath, "testplan", "", "testplan configuration file")
 
 	cobra.MarkFlagRequired(buildRunTestplanCmd.Flags(), "testplan")


### PR DESCRIPTION
When the testplan is already provided and contains a namespace that is
not available in the current cluster, a manual change in the testplan
would be required. It would be easier if an override using a command
line flag could take precedence over the configuration file.

Add flag `namespace` to override the namespace defined in the testplan.