### PR TITLE
Add missing source revision option

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -64,6 +64,7 @@ func applyBuildRunSettingsFlags(cmd *cobra.Command, buildCfg *load.BuildConfig) 
 
 	pf.StringVar(&buildCfg.SourceURL, "source-url", "", "specify source URL to build from")
 	pf.StringVar(&buildCfg.SourceContextDir, "source-context", "/", "specify directory to be used in the source repository")
+	pf.StringVar(&buildCfg.SourceRevision, "source-revision", "master", "specify the branch, tag, or commit to be used")
 	pf.StringVar(&buildCfg.SourceSecretRef, "source-secret", "", "specify secret to be used to access the source")
 	pf.StringVar(&buildCfg.SourceDockerfile, "dockerfile", "Dockerfile", "specify name of the docker file for kaniko builds")
 

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -53,6 +53,7 @@ type NamingConfig struct {
 type BuildConfig struct {
 	ClusterBuildStrategy string
 	SourceURL            string
+	SourceRevision       string
 	SourceContextDir     string
 	SourceSecretRef      string
 	SourceDockerfile     string
@@ -162,6 +163,7 @@ func createBuildSpec(name string, buildCfg BuildConfig) (*buildv1alpha.BuildSpec
 
 		Source: buildv1alpha.GitSource{
 			URL:        buildCfg.SourceURL,
+			Revision:   pointer.StringPtr(buildCfg.SourceRevision),
 			ContextDir: pointer.StringPtr(buildCfg.SourceContextDir),
 			SecretRef:  secrefRef(buildCfg.SourceSecretRef),
 		},


### PR DESCRIPTION
In case the branch in the source Git is not `master` the build failed.

Add option to specify the revision to be supplied into the build spec.