### PR TITLE
Add flag to disable service account generation

### DIFF
--- a/internal/cmd/buildrun-testplan.go
+++ b/internal/cmd/buildrun-testplan.go
@@ -25,8 +25,9 @@ import (
 )
 
 var buildRunTestplanCmdSettings struct {
-	namespace    string
-	testplanPath string
+	namespace              string
+	generateServiceAccount bool
+	testplanPath           string
 }
 
 var testplanCmdLong = `Run buildruns configured as steps in a testplan YAML file.
@@ -97,6 +98,7 @@ func init() {
 	buildRunTestplanCmd.PersistentFlags().SortFlags = false
 
 	buildRunTestplanCmd.Flags().StringVar(&buildRunTestplanCmdSettings.namespace, "namespace", "", "namespace to run tests in (takes precedence over namespace in testplan YAML)")
+	buildRunTestplanCmd.Flags().BoolVar(&buildRunTestplanCmdSettings.generateServiceAccount, "generate-service-account", true, "generate service account for build")
 	buildRunTestplanCmd.Flags().StringVar(&buildRunTestplanCmdSettings.testplanPath, "testplan", "", "testplan configuration file")
 
 	cobra.MarkFlagRequired(buildRunTestplanCmd.Flags(), "testplan")

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -64,6 +64,8 @@ func applyBuildRunSettingsFlags(cmd *cobra.Command, buildCfg *load.BuildConfig) 
 
 	pf.StringVar(&buildCfg.ClusterBuildStrategy, "cluster-build-strategy", "", "specify which cluster build strategy to be tested")
 
+	pf.BoolVar(&buildCfg.GenerateServiceAccount, "generate-service-account", true, "generate service account for each build")
+
 	pf.StringVar(&buildCfg.SourceURL, "source-url", "", "specify source URL to build from")
 	pf.StringVar(&buildCfg.SourceContextDir, "source-context", "/", "specify directory to be used in the source repository")
 	pf.StringVar(&buildCfg.SourceRevision, "source-revision", "master", "specify the branch, tag, or commit to be used")

--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -140,7 +140,7 @@ func CheckSystemAndConfig(kubeAccess KubeAccess, buildCfg BuildConfig, parallel 
 }
 
 // ExecuteSingleBuildRun executes a single buildrun based on the given settings
-func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string, buildSpec buildv1alpha1.BuildSpec) (*BuildRunResult, error) {
+func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string, generateServiceAccount bool, buildSpec buildv1alpha1.BuildSpec) (*BuildRunResult, error) {
 	build, err := applyBuild(kubeAccess, newBuild(namespace, name, buildSpec))
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string,
 		}
 	}()
 
-	buildRun, err := applyBuildRun(kubeAccess, newBuildRun(name, *build))
+	buildRun, err := applyBuildRun(kubeAccess, newBuildRun(name, *build, generateServiceAccount))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func ExecuteParallelBuildRuns(kubeAccess KubeAccess, namingCfg NamingConfig, bui
 				return
 			}
 
-			result, err := ExecuteSingleBuildRun(kubeAccess, namespace, name, *buildSpec)
+			result, err := ExecuteSingleBuildRun(kubeAccess, namespace, name, buildCfg.GenerateServiceAccount, *buildSpec)
 			if err != nil {
 				errors <- err
 				return
@@ -286,7 +286,7 @@ func ExecuteTestPlan(kubeAccess KubeAccess, testplan TestPlan) error {
 
 		step.BuildSpec.Output.ImageURL = outputImageURL
 
-		if _, err := ExecuteSingleBuildRun(kubeAccess, testplan.Namespace, name, step.BuildSpec); err != nil {
+		if _, err := ExecuteSingleBuildRun(kubeAccess, testplan.Namespace, name, testplan.GenerateServiceAccount, step.BuildSpec); err != nil {
 			return err
 		}
 	}

--- a/internal/load/kubeops.go
+++ b/internal/load/kubeops.go
@@ -53,7 +53,7 @@ func newBuild(namespace string, name string, buildSpec buildv1alpha1.BuildSpec) 
 	}
 }
 
-func newBuildRun(name string, build buildv1alpha1.Build) buildv1alpha1.BuildRun {
+func newBuildRun(name string, build buildv1alpha1.Build, generateServiceAccount bool) buildv1alpha1.BuildRun {
 	return buildv1alpha1.BuildRun{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "BuildRun",
@@ -71,7 +71,7 @@ func newBuildRun(name string, build buildv1alpha1.Build) buildv1alpha1.BuildRun 
 			},
 
 			ServiceAccount: &buildv1alpha1.ServiceAccount{
-				Generate: true,
+				Generate: generateServiceAccount,
 			},
 		},
 	}

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -52,15 +52,16 @@ type NamingConfig struct {
 
 // BuildConfig contains all fields required to setup a buildRun
 type BuildConfig struct {
-	ClusterBuildStrategy string
-	SourceURL            string
-	SourceRevision       string
-	SourceContextDir     string
-	SourceSecretRef      string
-	SourceDockerfile     string
-	OutputImageURL       string
-	OutputSecretRef      string
-	Timeout              time.Duration
+	ClusterBuildStrategy   string
+	SourceURL              string
+	SourceRevision         string
+	SourceContextDir       string
+	SourceSecretRef        string
+	SourceDockerfile       string
+	GenerateServiceAccount bool
+	OutputImageURL         string
+	OutputSecretRef        string
+	Timeout                time.Duration
 }
 
 // BuildRunResultSet is an aggregated result set based on multiple
@@ -85,8 +86,9 @@ type BuildRunResult struct {
 
 // TestPlan is a plan with steps that define tests
 type TestPlan struct {
-	Namespace string `yaml:"namespace" json:"namespace"`
-	Steps     []struct {
+	Namespace              string `yaml:"namespace" json:"namespace"`
+	GenerateServiceAccount bool   `yaml:"generateServiceAccount" json:"generateServiceAccount"`
+	Steps                  []struct {
 		Name      string                 `yaml:"name" json:"name"`
 		BuildSpec buildv1alpha.BuildSpec `yaml:"buildSpec" json:"buildSpec"`
 	} `yaml:"steps" json:"steps"`


### PR DESCRIPTION
By default, the `build-load` tool is creating a service account for each
buildrun through a setting in the buildrun configuration.

Add flag to disable the generation of the service account for the build.