### PR TITLE
Add force delete when cleaning up env before testing

### DIFF
--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -146,9 +146,15 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string,
 		return nil, err
 	}
 
+	// Force clean env before starting test.
+	debug("Force clean env before starting test")
+
+	var graceperiod int64 = int64(0)
+	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &graceperiod}
+
 	defer func() {
 		debug("Delete build %s", build.Name)
-		if err := kubeAccess.BuildClient.BuildV1alpha1().Builds(build.Namespace).Delete(build.Name, &metav1.DeleteOptions{}); err != nil {
+		if err := kubeAccess.BuildClient.BuildV1alpha1().Builds(build.Namespace).Delete(build.Name, &deleteOptions); err != nil {
 			warn("failed to delete build %s, %v\n", name, err)
 		}
 	}()
@@ -160,7 +166,7 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string,
 
 	defer func() {
 		debug("Delete buildrun %s", buildRun.Name)
-		if err := kubeAccess.BuildClient.BuildV1alpha1().BuildRuns(buildRun.Namespace).Delete(buildRun.Name, &metav1.DeleteOptions{}); err != nil {
+		if err := kubeAccess.BuildClient.BuildV1alpha1().BuildRuns(buildRun.Namespace).Delete(buildRun.Name, &deleteOptions); err != nil {
 			warn("failed to delete buildrun %s, %v\n", name, err)
 		}
 	}()


### PR DESCRIPTION
First add force delete (graceperiod=0) before testing start, following by this suggestion: https://github.com/fabric8io/kubernetes-client/issues/1195#issuecomment-461041903

I will add more commits for minor updates in this PR. 