### PR TITLE
Change build-operator to shipwright-build-controller

### DIFF
--- a/internal/load/build.go
+++ b/internal/load/build.go
@@ -63,7 +63,7 @@ func registerSingleBuild(kubeAccess KubeAccess, namespace string, name string, b
 	var buildRegisteredTime time.Time
 
 	for _, mf := range build.ManagedFields {
-		if mf.Operation == metav1.ManagedFieldsOperationUpdate && mf.Manager == "build-operator" {
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate && mf.Manager == "shipwright-build-controller" {
 			buildRegisteredTime = mf.Time.Time
 		}
 	}


### PR DESCRIPTION
I am correcting the name of the expected manager in the `managedFields` to be able to determine the correct build registration time.