### PR TITLE
Fix BuildRun control time

### DIFF
--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -225,7 +225,7 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string,
 			buildRunResult = append(buildRunResult,
 				Value{
 					BuildrunControlTime,
-					duration(buildRun.Status.StartTime.Time, taskRun.Status.StartTime.Time),
+					duration(buildRun.CreationTimestamp.Time, taskRun.CreationTimestamp.Time),
 				},
 			)
 


### PR DESCRIPTION
The existing duration was TaskRun startTime minus BuildRun startTime which does not make sense because it is the same value. See [here](https://github.com/shipwright-io/build/blob/f5ddd1e70eefe779f6be7b7fe826107fddf4baf1/pkg/reconciler/buildrun/buildrun.go#L231). The resulting value reported by `build-load` has therefore always been `0`.

What I see as BuildRun control time is how long it takes for a newly created BuildRun to create the TaskRun.