### PR TITLE
Introduce service account name flag

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -69,7 +69,7 @@ func applyBuildRunSettingsFlags(cmd *cobra.Command, buildCfg *load.BuildConfig) 
 
 	pf.StringVar(&buildCfg.ClusterBuildStrategy, "cluster-build-strategy", "", "specify which cluster build strategy to be tested")
 
-	pf.BoolVar(&buildCfg.GenerateServiceAccount, "generate-service-account", true, "generate service account for each build")
+	pf.StringVar(&buildCfg.ServiceAccountName, "service-account-name", "generated", "service account to be used, use name 'generated' to generate a new one, an empty string configures the system default service account")
 
 	pf.StringVar(&buildCfg.SourceURL, "source-url", "", "specify source URL to build from")
 	pf.StringVar(&buildCfg.SourceContextDir, "source-context", "/", "specify directory to be used in the source repository")

--- a/internal/load/build.go
+++ b/internal/load/build.go
@@ -144,7 +144,7 @@ func ExecuteBuilds(kubeAccess KubeAccess, namingCfg NamingConfig, buildCfg Build
 				name,
 				*buildSpec,
 				buildAnnotations,
-				GenerateServiceAccount(buildCfg.GenerateServiceAccount),
+				ServiceAccountName(buildCfg.ServiceAccountName),
 				SkipDelete(buildCfg.SkipDelete),
 			)
 

--- a/internal/load/buildrun.go
+++ b/internal/load/buildrun.go
@@ -33,8 +33,8 @@ import (
 )
 
 type buildRunOptions struct {
-	generateServiceAccount bool
-	skipDelete             bool
+	serviceAccountName string
+	skipDelete         bool
 }
 
 // BuildRunOption specifies optional settings for a buildrun
@@ -150,10 +150,10 @@ func CheckSystemAndConfig(kubeAccess KubeAccess, buildCfg BuildConfig, parallel 
 	return nil
 }
 
-// GenerateServiceAccount sets whether or not a service account is created for the buildrun
-func GenerateServiceAccount(value bool) BuildRunOption {
+// ServiceAccountName sets the service account to be used, use empty string to generate one
+func ServiceAccountName(value string) BuildRunOption {
 	return func(o *buildRunOptions) {
-		o.generateServiceAccount = value
+		o.serviceAccountName = value
 	}
 }
 
@@ -184,7 +184,7 @@ func ExecuteSingleBuildRun(kubeAccess KubeAccess, namespace string, name string,
 		}()
 	}
 
-	buildRun, err := applyBuildRun(kubeAccess, newBuildRun(name, *build, buildRunOptions.generateServiceAccount))
+	buildRun, err := applyBuildRun(kubeAccess, newBuildRun(name, *build, buildRunOptions.serviceAccountName))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func ExecuteParallelBuildRuns(kubeAccess KubeAccess, namingCfg NamingConfig, bui
 				name,
 				*buildSpec,
 				buildAnnotations,
-				GenerateServiceAccount(buildCfg.GenerateServiceAccount),
+				ServiceAccountName(buildCfg.ServiceAccountName),
 				SkipDelete(buildCfg.SkipDelete),
 			)
 
@@ -357,7 +357,7 @@ func ExecuteTestPlan(kubeAccess KubeAccess, testplan TestPlan) error {
 
 		step.BuildSpec.Output.Image = outputImageURL
 
-		if _, err := ExecuteSingleBuildRun(kubeAccess, testplan.Namespace, name, step.BuildSpec, step.BuildAnnotations, GenerateServiceAccount(testplan.GenerateServiceAccount)); err != nil {
+		if _, err := ExecuteSingleBuildRun(kubeAccess, testplan.Namespace, name, step.BuildSpec, step.BuildAnnotations, ServiceAccountName(testplan.ServiceAccountName)); err != nil {
 			return err
 		}
 	}

--- a/internal/load/kubeops.go
+++ b/internal/load/kubeops.go
@@ -63,7 +63,7 @@ func newBuild(namespace string, name string, buildSpec buildv1alpha1.BuildSpec, 
 	}
 }
 
-func newBuildRun(name string, build buildv1alpha1.Build, generateServiceAccount bool) buildv1alpha1.BuildRun {
+func newBuildRun(name string, build buildv1alpha1.Build, serviceAccountName string) buildv1alpha1.BuildRun {
 	return buildv1alpha1.BuildRun{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "BuildRun",
@@ -80,9 +80,21 @@ func newBuildRun(name string, build buildv1alpha1.Build, generateServiceAccount 
 				Name: build.Name,
 			},
 
-			ServiceAccount: &buildv1alpha1.ServiceAccount{
-				Generate: generateServiceAccount,
-			},
+			ServiceAccount: func() *buildv1alpha1.ServiceAccount {
+				if serviceAccountName == "generated" {
+					return &buildv1alpha1.ServiceAccount{
+						Generate: true,
+					}
+				}
+
+				if serviceAccountName != "" {
+					return &buildv1alpha1.ServiceAccount{
+						Name: &serviceAccountName,
+					}
+				}
+
+				return nil
+			}(),
 		},
 	}
 }

--- a/internal/load/models.go
+++ b/internal/load/models.go
@@ -72,7 +72,7 @@ type BuildConfig struct {
 	SourceContextDir           string
 	SourceSecretRef            string
 	SourceDockerfile           string
-	GenerateServiceAccount     bool
+	ServiceAccountName         string
 	OutputImageURL             string
 	OutputSecretRef            string
 	Timeout                    time.Duration
@@ -104,9 +104,9 @@ type Result []Value
 
 // TestPlan is a plan with steps that define tests
 type TestPlan struct {
-	Namespace              string `yaml:"namespace" json:"namespace"`
-	GenerateServiceAccount bool   `yaml:"generateServiceAccount" json:"generateServiceAccount"`
-	Steps                  []struct {
+	Namespace          string `yaml:"namespace" json:"namespace"`
+	ServiceAccountName string `yaml:"serviceAccountName" json:"serviceAccountName"`
+	Steps              []struct {
 		Name             string                 `yaml:"name" json:"name"`
 		BuildAnnotations map[string]string      `yaml:"buildAnnotations" json:"buildAnnotations"`
 		BuildSpec        buildv1alpha.BuildSpec `yaml:"buildSpec" json:"buildSpec"`


### PR DESCRIPTION
Discontinue `--generate-service-account` in favor for `--service-account-name`
to set a service account to be used. Empty string (default) will lead to the
creation of a service account.
