### PR TITLE
Tweak Ginkgo install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
         make test
 
     - name: Upload Code Coverage Profile


### PR DESCRIPTION
Add `-mod=mod` to hopefully get rid of `go.sum` issues.
